### PR TITLE
Update both tokens when refresh

### DIFF
--- a/authentication.js
+++ b/authentication.js
@@ -49,7 +49,8 @@ const refreshAccessToken = (z, bundle) => {
 
     const result = JSON.parse(response.content);
     return {
-      access_token: result.access_token
+      access_token: result.access_token,
+      refresh_token: result.refresh_token
     };
   });
 };


### PR DESCRIPTION
refreshAccessToken method, should return both refresh_token and access_token values to be stored back in bundle, exaclty like getAccessToken method does. I tried that with Laravel Passport which failed to auth in the second refresh since it the tokens pair would not match any more.

Closes #6